### PR TITLE
Changed InternalFilewatchFN signature from `Void` to `void` in linc_f…

### DIFF
--- a/linc/linc_filewatch.h
+++ b/linc/linc_filewatch.h
@@ -21,7 +21,7 @@ namespace linc {
                 fe_create                       = 3
             }; //FilewatchEventType
 
-            typedef ::cpp::Function < Void(int, ::String) > InternalFilewatchFN;
+            typedef ::cpp::Function < void(int, ::String) > InternalFilewatchFN;
 
         //internal
 


### PR DESCRIPTION
Changed InternalFilewatchFN signature from `Void` to `void` in linc_filewatch.h. Fixes compilation for latest Haxe / HXCpp.

Fix resolves snowkit/linc_filewatch#1
